### PR TITLE
remove importnb-run entry_point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup_args = dict(
         'console_scripts': [
             'importnb-install = importnb.utils.ipython:install',
             'importnb-uninstall = importnb.utils.ipython:uninstall',
-            'importnb-run = importnb.loader:main',
             'nbdoctest = importnb.utils.nbdoctest:_test',
         ]
     },


### PR DESCRIPTION
It appears `importnb.loader:main` went away.